### PR TITLE
fix @types/eslint dependency resolving

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,22 @@
 {
   "name": "eslint-plugin-react-component-name",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-react-component-name",
-      "version": "0.0.1",
+      "version": "0.0.4",
       "license": "MIT",
+      "dependencies": {
+        "@types/eslint": "^8.56.12"
+      },
       "devDependencies": {
-        "@types/eslint": "^9.6.1",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "@typescript-eslint/rule-tester": "^7.18.0",
         "eslint": "^8.57.1",
-        "smartbundle": "^0.11.1",
+        "smartbundle": "^0.12.1",
         "vitest": "^2.1.8"
       }
     },
@@ -809,10 +811,10 @@
       ]
     },
     "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
+      "version": "8.56.12",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
+      "integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -822,14 +824,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
@@ -2735,29 +2735,33 @@
       }
     },
     "node_modules/smartbundle": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/smartbundle/-/smartbundle-0.11.1.tgz",
-      "integrity": "sha512-OJKnBN447Zp6Qunkk0E15VOURmL3dEsWPGw2kondSPam3ZHKvzHvxbz7e01ZIQI61kCXl3F5dy9ibjzkQjk/IA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/smartbundle/-/smartbundle-0.12.1.tgz",
+      "integrity": "sha512-3g5m3GJ9uYI8IN0lkBe+5ib91WEcyaOFvDYb/A/n6PROeYZW/RP/aRlbP7SGDM7EqQv9+jpe3cgYD1UD8YrIGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.6.3",
         "vite": "^5.4.11",
         "yargs": "^17.7.2",
-        "zod": "^3.23.8"
+        "zod": "^3.24.0"
       },
       "bin": {
         "smartbundle": "__bin__/smartbundle.js"
       },
       "peerDependencies": {
         "@babel/core": "^7.26.0",
-        "typescript": "^5.6.3"
+        "typescript": "^5.0.0",
+        "vitest": "^2.1.8"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
           "optional": true
         },
         "typescript": {
+          "optional": true
+        },
+        "vitest": {
           "optional": true
         }
       }
@@ -3238,9 +3242,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -24,13 +24,15 @@
     "url": "https://github.com/artalar/eslint-plugin-react-component-name/issues"
   },
   "homepage": "https://github.com/artalar/eslint-plugin-react-component-name#readme",
+  "dependencies": {
+    "@types/eslint": "^8.56.12"
+  },
   "devDependencies": {
-    "@types/eslint": "^9.6.1",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "@typescript-eslint/rule-tester": "^7.18.0",
     "eslint": "^8.57.1",
-    "smartbundle": "^0.11.1",
+    "smartbundle": "^0.12.1",
     "vitest": "^2.1.8"
   }
 }


### PR DESCRIPTION
The current version of the lib has an issue: @types/eslint is not installed in the user's node_modules.

The new version of smartbundle can handle this type of issue
<img width="962" alt="image" src="https://github.com/user-attachments/assets/aaf629c5-37c1-4e6b-888f-b57ca715a9ce" />

I've upgraded smartbundle and fixed the above issue